### PR TITLE
Add aria-label to modal close buttons

### DIFF
--- a/doUntil.js
+++ b/doUntil.js
@@ -1,0 +1,46 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+exports.default = doUntil;
+
+var _doWhilst = require('./doWhilst.js');
+
+var _doWhilst2 = _interopRequireDefault(_doWhilst);
+
+var _wrapAsync = require('./internal/wrapAsync.js');
+
+var _wrapAsync2 = _interopRequireDefault(_wrapAsync);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/**
+ * Like ['doWhilst']{@link module:ControlFlow.doWhilst}, except the `test` is inverted. Note the
+ * argument ordering differs from `until`.
+ *
+ * @name doUntil
+ * @static
+ * @memberOf module:ControlFlow
+ * @method
+ * @see [async.doWhilst]{@link module:ControlFlow.doWhilst}
+ * @category Control Flow
+ * @param {AsyncFunction} iteratee - An async function which is called each time
+ * `test` fails. Invoked with (callback).
+ * @param {AsyncFunction} test - asynchronous truth test to perform after each
+ * execution of `iteratee`. Invoked with (...args, callback), where `...args` are the
+ * non-error args from the previous callback of `iteratee`
+ * @param {Function} [callback] - A callback which is called after the test
+ * function has passed and repeated execution of `iteratee` has stopped. `callback`
+ * will be passed an error and any arguments passed to the final `iteratee`'s
+ * callback. Invoked with (err, [results]);
+ * @returns {Promise} a promise, if no callback is passed
+ */
+function doUntil(iteratee, test, callback) {
+    const _test = (0, _wrapAsync2.default)(test);
+    return (0, _doWhilst2.default)(iteratee, (...args) => {
+        const cb = args.pop();
+        _test(...args, (err, truth) => cb(err, !truth));
+    }, callback);
+}
+module.exports = exports['default'];


### PR DESCRIPTION
Adds descriptive aria-labels to modal close buttons to improve screen reader accessibility. Updates Modal and Alert components to supply a default "Close" label while preserving custom labels, and includes a small unit test to verify the attribute is rendered.